### PR TITLE
fix: main branch references renamed to master

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "main"
+    target-branch: "master"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,7 +6,7 @@ name: Build and publish
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   buildAndPublish:


### PR DESCRIPTION
## Fixed
+ `main` branch references renamed to `master`

Closes #7 