### PR TITLE
feat(types): preserve enum literal values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-07-03
+
+### Added
+
+- Literal-aware TypeScript definitions for enum values, names, labels, `get()`, and `toArray()`.
+- Compile-time type assertions covering literal inference.
+- Expanded README documentation for runtime behavior, validation errors, TypeScript usage, and exported helper types.
+
+### Changed
+
+- Updated TypeScript from 4.6 to 5.9 so declarations can use `const` type parameters.
+
 ## [2.1.0] - 2026-03-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,86 +1,184 @@
-We use this *enum-helper* module to easier create and manipulate enums in JavaScript.
+# @enterwell/enum-helper
 
-Features:
- - Create Enum object
- - Access Enum objects by value or by name
- - Return Enum array
+JavaScript enum helper for creating small enum-like objects that can be accessed by name, looked up by numeric value, and converted back to an array.
+
+## Features
+
+- Create an enum object from an array of enum definitions
+- Access enum entries by their `name`
+- Look up enum entries by their numeric `value`
+- Return enum entries as an array with `toArray()`
+- Preserve concrete TypeScript literal values for `value`, `name`, and `label`
+- Publish both ESM and CommonJS builds
 
 ## Install
 
-```
-$ npm install --save @enterwell/enum-helper
-```
-or with yarn
-```
-$ yarn add @enterwell/enum-helper
+```sh
+npm install @enterwell/enum-helper
 ```
 
+or:
+
+```sh
+yarn add @enterwell/enum-helper
+```
+
+## Requirements
+
+- Runtime enum values must be numbers.
+- Runtime enum names and labels must be strings.
+- TypeScript consumers should use TypeScript 5 or newer so the package declarations can preserve literal values with `const` type parameters.
 
 ## Usage
-
-```js
-import Enum from '@enterwell/enum-helper';
-```
-
-## API
-
-### Enum 
-
-#### enumArray<enumObject>
-
-Type: `array`
-
-Array of enum objects.
-
-#### enumObject
-
-Type: `object`
-
-Enum object. 
-Has this shape: *{ value: Number, name: String, label: String }*
-
-### get(enumValue)
-
-Find Enum object by value and return it.
-
-### enumValue
-
-Type: `number`
-
-Enum object value
-
-## Code usage
 
 ```javascript
 import Enum from '@enterwell/enum-helper';
 
-// Enum data
 const packagingData = [
-  {value: 0, name: 'Small', label: 'Small size'},
-  {value: 1, name: 'Large', label: 'Large size'}
+  { value: 0, name: 'Small', label: 'Small size' },
+  { value: 1, name: 'Large', label: 'Large size' }
 ];
 
-// Create packagingEnum object (enum representation) from enum data
 const packagingEnum = new Enum(packagingData);
 
-// Get Enum value by name property
 packagingEnum.Small.value; // 0
 packagingEnum.Small.label; // 'Small size'
+packagingEnum.Small; // { value: 0, name: 'Small', label: 'Small size' }
 
-// Get Enum object by name property
-packagingEnum.Small; // {value: 0, name: 'Small', label: 'Small size'}
+packagingEnum.get(0); // { value: 0, name: 'Small', label: 'Small size' }
+packagingEnum.toArray(); // Same entries as packagingData
+```
 
-// Get Enum object by enum value with .get method
-packagingEnum.get(0); // {value: 0, name: 'Small', label: 'Small size'}
+## API
 
-// Return original array with which Enum object was initalized
-packagingEnum.toArray(); // The same as packagingData const 
+### `new Enum(enumData)`
 
-// Get to not existing value throws an exception
-packagingEnum.get(100); // ReferenceError ('Enum object not found');
+Creates an enum helper instance.
 
+`enumData` must be an array of objects with this shape:
+
+```typescript
+{
+  value: number;
+  name: string;
+  label: string;
+}
+```
+
+Each `name` and `value` must be unique.
+
+### Named entries
+
+Each enum entry is assigned to the instance by its `name`.
+
+```javascript
+packagingEnum.Small; // { value: 0, name: 'Small', label: 'Small size' }
+packagingEnum.Large; // { value: 1, name: 'Large', label: 'Large size' }
+```
+
+### `get(enumValue)`
+
+Returns the enum entry for a numeric value.
+
+```javascript
+packagingEnum.get(1); // { value: 1, name: 'Large', label: 'Large size' }
+```
+
+Throws `ReferenceError('Enum object not found')` when no enum entry exists for the given value.
+
+### `toArray()`
+
+Returns the enum entries as an array.
+
+```javascript
+packagingEnum.toArray();
+// [
+//   { value: 0, name: 'Small', label: 'Small size' },
+//   { value: 1, name: 'Large', label: 'Large size' }
+// ]
+```
+
+Numeric values do not need to be sequential:
+
+```javascript
+const statusEnum = new Enum([
+  { value: 0, name: 'Draft', label: 'Draft' },
+  { value: 10, name: 'Published', label: 'Published' }
+]);
+
+statusEnum.toArray().length; // 2
+```
+
+## Validation Errors
+
+The constructor validates enum data and throws:
+
+- `TypeError('Enum name have to be string value!')` when an entry name is not a string
+- `TypeError('Enum value have to be an integer!')` when an entry value is not a number
+- `TypeError('Enum already contains an object with same name!')` when names are duplicated
+- `TypeError('Enum already contains an object with same value!')` when values are duplicated
+
+## TypeScript
+
+The package preserves concrete enum data values in its types.
+
+```typescript
+import Enum from '@enterwell/enum-helper';
+
+const packagingEnum = new Enum([
+  { value: 0, name: 'Small', label: 'Small size' },
+  { value: 1, name: 'Large', label: 'Large size' }
+]);
+
+packagingEnum.Small.value; // 0
+packagingEnum.Small.name; // 'Small'
+packagingEnum.Small.label; // 'Small size'
+packagingEnum.get(1).value; // 1
+packagingEnum.toArray()[0].value; // 0 | 1
+```
+
+When enum data is stored before calling `new Enum(...)`, use `as const` to keep literal values:
+
+```typescript
+const packagingData = [
+  { value: 0, name: 'Small', label: 'Small size' },
+  { value: 1, name: 'Large', label: 'Large size' }
+] as const;
+
+const packagingEnum = new Enum(packagingData);
+
+packagingEnum.Large.value; // 1
+```
+
+### Exported Types
+
+The package exports these TypeScript helper types:
+
+- `EnumValue`
+- `EnumDef`
+- `EnumData`
+- `EnumItem`
+- `EnumByName`
+- `EnumByValue`
+- `EnumType`
+- `EnumMethods`
+- `EnumInstance`
+- `Enum`
+- `EnumConstructor`
+
+Example:
+
+```typescript
+import Enum, { type Enum as EnumInstance } from '@enterwell/enum-helper';
+
+const packagingData = [
+  { value: 0, name: 'Small', label: 'Small size' },
+  { value: 1, name: 'Large', label: 'Large size' }
+] as const;
+
+const packagingEnum: EnumInstance<typeof packagingData> = new Enum(packagingData);
 ```
 
 ## License
 
-MIT © [Enterwell](http://enterwell.net)
+MIT (c) [Enterwell](http://enterwell.net)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@enterwell/enum-helper",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "JavaScript enum helper.",
   "license": "MIT",
   "repository": "https://github.com/Enterwell/js-enum-helper",
@@ -51,6 +51,6 @@
     "babel-jest": "^27.5.1",
     "jest": "^27.5.1",
     "tsup": "^8.5.1",
-    "typescript": "^4.6.3"
+    "typescript": "^5.9.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,40 @@
-export interface EnumType {
-    [key: string]: EnumDef | undefined;
+export type EnumValue = number;
+
+export interface EnumDef<
+    TValue extends EnumValue = EnumValue,
+    TName extends string = string,
+    TLabel extends string = string
+> {
+    name: TName,
+    value: TValue,
+    label: TLabel
 }
 
-export interface EnumDef {
-    name: string,
-    value: number,
-    label: string
+export type EnumData = readonly EnumDef[];
+export type EnumItem<TEnumData extends EnumData> = TEnumData[number];
+export type EnumByName<TEnumData extends EnumData> = {
+    [TEnum in EnumItem<TEnumData> as TEnum['name']]: TEnum;
+};
+export type EnumByValue<
+    TEnumData extends EnumData,
+    TValue extends EnumItem<TEnumData>['value']
+> = Extract<EnumItem<TEnumData>, { value: TValue }>;
+export type EnumType<TEnumData extends EnumData = EnumData> = EnumByName<TEnumData>;
+
+export interface EnumMethods<TEnumData extends EnumData = EnumData> {
+    _array: EnumItem<TEnumData>[];
+    _setEnumData(enumData: TEnumData): void;
+    _setEnumDataToArray(enumData: TEnumData): void;
+    get<TValue extends EnumItem<TEnumData>['value']>(enumValue: TValue): EnumByValue<TEnumData, TValue>;
+    get(enumValue: EnumValue): EnumItem<TEnumData>;
+    toArray(): EnumItem<TEnumData>[];
+}
+
+export type EnumInstance<TEnumData extends EnumData = EnumData> = EnumMethods<TEnumData> & EnumType<TEnumData>;
+export type Enum<TEnumData extends EnumData = EnumData> = EnumInstance<TEnumData>;
+
+export interface EnumConstructor {
+    new <const TEnumData extends EnumData>(enumData: TEnumData): EnumInstance<TEnumData>;
 }
 
 /**
@@ -13,10 +42,8 @@ export interface EnumDef {
  * 
  * @class Enum
  */
-class Enum {
-    [key: string]: EnumDef | undefined | ((enumValue: number) => EnumDef) | (() => EnumDef[]) | ((enumData: EnumDef[]) => void) | EnumDef[];
-    
-    _array: EnumDef[] = [];
+class EnumImpl<const TEnumData extends EnumData = EnumData> implements EnumMethods<TEnumData> {
+    _array: EnumItem<TEnumData>[] = [];
 
     /**
      * Creates an instance of Enum.
@@ -28,7 +55,7 @@ class Enum {
      * 
      * @memberOf Enum
      */
-    constructor(enumData: EnumDef[]) {
+    constructor(enumData: TEnumData) {
         this._setEnumData = this._setEnumData.bind(this);
         this._setEnumDataToArray = this._setEnumDataToArray.bind(this);
         this.get = this.get.bind(this);
@@ -51,7 +78,9 @@ class Enum {
      * 
      * @memberOf Enum
      */
-    _setEnumData(enumData: EnumDef[]) {
+    _setEnumData(enumData: TEnumData) {
+        const enumObject = this as unknown as Record<string, EnumItem<TEnumData> | undefined>;
+
         // sets the enum data as properties
         enumData.forEach((singleEnum) => {
             // Validate enum name - have to be string
@@ -63,11 +92,11 @@ class Enum {
                 throw new TypeError('Enum value have to be an integer!');
 
             // If enum already contains object with same name
-            if (this[singleEnum.name] !== undefined)
+            if (enumObject[singleEnum.name] !== undefined)
                 throw new TypeError('Enum already contains an object with same name!');
 
             // sets the data as property
-            this[singleEnum.name] = singleEnum;
+            enumObject[singleEnum.name] = singleEnum;
         });
     }
 
@@ -81,7 +110,7 @@ class Enum {
      * 
      * @memberOf Enum
      */
-    _setEnumDataToArray(enumData: EnumDef[]) {
+    _setEnumDataToArray(enumData: TEnumData) {
         // iterates over the enum data
         enumData.forEach((singleEnum) => {
             // Check if object with same value already exists
@@ -99,7 +128,9 @@ class Enum {
      * 
      * @memberOf Enum
      */
-    get(enumValue: number) {
+    get<TValue extends EnumItem<TEnumData>['value']>(enumValue: TValue): EnumByValue<TEnumData, TValue>;
+    get(enumValue: EnumValue): EnumItem<TEnumData>;
+    get(enumValue: EnumValue) {
         // Get enum object from array by value key
         const enumObject = this._array[enumValue];
 
@@ -120,9 +151,11 @@ class Enum {
      */
     toArray() {
         // Copy array and return the copy
-        return this._array.filter(e => e);
+        return this._array.filter((e): e is EnumItem<TEnumData> => Boolean(e));
     }
 }
 
 // Export class
-export default Enum;
+const EnumConstructorValue = EnumImpl as EnumConstructor;
+
+export default EnumConstructorValue;

--- a/src/index.type-test.ts
+++ b/src/index.type-test.ts
@@ -1,0 +1,33 @@
+import Enum from './index';
+
+type Equal<TActual, TExpected> = (
+    <TValue>() => TValue extends TActual ? 1 : 2
+) extends (
+    <TValue>() => TValue extends TExpected ? 1 : 2
+) ? true : false;
+type Expect<TValue extends true> = TValue;
+
+const packagingEnum = new Enum([
+    { value: 0, name: 'Small', label: 'Small size' },
+    { value: 1, name: 'Large', label: 'Large size' }
+]);
+
+const largePackaging = packagingEnum.get(1);
+const packagingArray = packagingEnum.toArray();
+
+type InlineValue = Expect<Equal<typeof packagingEnum.Small.value, 0>>;
+type InlineName = Expect<Equal<typeof packagingEnum.Small.name, 'Small'>>;
+type InlineLabel = Expect<Equal<typeof packagingEnum.Small.label, 'Small size'>>;
+type GetValue = Expect<Equal<typeof largePackaging.value, 1>>;
+type ArrayValue = Expect<Equal<typeof packagingArray[number]['value'], 0 | 1>>;
+
+const storedEnumData = [
+    { value: 2, name: 'Medium', label: 'Medium size' },
+    { value: 3, name: 'Huge', label: 'Huge size' }
+] as const;
+
+const storedEnum = new Enum(storedEnumData);
+
+type StoredValue = Expect<Equal<typeof storedEnum.Huge.value, 3>>;
+type StoredName = Expect<Equal<typeof storedEnum.Huge.name, 'Huge'>>;
+type StoredLabel = Expect<Equal<typeof storedEnum.Huge.label, 'Huge size'>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
         "isolatedModules": true,
         // Import non-ES modules as default imports.
         "esModuleInterop": true,
+        "types": [],
         "declaration": true,
         "declarationDir": "dist"
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,10 +3854,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
-  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
+typescript@^5.9.3:
+  version "5.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
+  integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
 ufo@^1.6.3:
   version "1.6.3"


### PR DESCRIPTION
## Summary

- Preserve concrete enum `value`, `name`, and `label` literals in TypeScript types.
- Type `get()` by the requested enum value and return literal unions from `toArray()`.
- Bump the package to `3.0.0` because the declarations now require TypeScript 5 `const` type parameters.
- Refresh README/API docs and changelog coverage for runtime behavior, validation errors, TypeScript usage, and exported helper types.

## Impact

TypeScript consumers get exact enum entry types instead of broad `string` and `number` fields. Consumers compiling package declarations with TypeScript 4 should upgrade to TypeScript 5+.

## Validation

- `yarn test`